### PR TITLE
Update the requirements and fix the installation with setup.py

### DIFF
--- a/WordlistRaider.py
+++ b/WordlistRaider.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import sys
 import argparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,3 @@
-atomicwrites==1.4.0
-attrs==20.1.0
-colorama==0.4.3
-iniconfig==1.0.1
-more-itertools==8.5.0
-packaging==20.4
-pluggy==0.13.1
-py==1.9.0
-pyparsing==2.4.7
-pytest==6.0.1
-six==1.15.0
-toml==0.10.1
+colorama>=0.4.3
+more_termcolor
+pyfiglet

--- a/setup.py
+++ b/setup.py
@@ -8,18 +8,9 @@ setup(
     version='1.0',
     python_requires='>=3.7',
     install_requires=[
-        "atomicwrites==1.4.0",
-        "attrs==20.1.0",
         "colorama==0.4.3",
-        "iniconfig==1.0.1",
-        "more-itertools==8.5.0",
-        "packaging==20.4",
-        "pluggy==0.13.1",
-        "py==1.9.0",
-        "pyparsing==2.4.7",
-        "pytest==6.0.1",
-        "six==1.15.0",
-        "toml==0.10.1"
+        "more_termcolor",
+        "pyfiglet"
     ],
     packages=find_packages()+['.'],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ setup(
         "more_termcolor",
         "pyfiglet"
     ],
-    packages=find_packages(),
-    include_package_data=True,
     url='https://github.com/GregorBiswanger/WordlistRaider',
     license='MIT',
     description='Returns a selection of words that matches the passed conditions in an existing list.',
@@ -24,9 +22,5 @@ setup(
         "Operating System :: OS Independent",
     ],
     keywords='wordlist passwordlist cutter raider',
-    entry_points={
-        'console_scripts': [
-            'wordlistraider = wordlistraider.WordlistRaider',
-        ],
-    },
+    scripts=['WordlistRaider.py'],
 )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     keywords='wordlist passwordlist cutter raider',
     entry_points={
         'console_scripts': [
-            'wordlistraider = wordlistraider.wordlistraider',
+            'wordlistraider = wordlistraider.WordlistRaider',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         "more_termcolor",
         "pyfiglet"
     ],
-    packages=find_packages()+['.'],
+    packages=find_packages(),
     include_package_data=True,
     url='https://github.com/GregorBiswanger/WordlistRaider',
     license='MIT',


### PR DESCRIPTION
Hello,
I have packaged this tool for Kali and I noticed little issues:

- A lot of requirements are listed in setup.py and in requirements.txt but they are not used / imported by WordlistRaider.py
And 2 are missing: pyfiglet and more_termcolor

- the setup.py installs the current directory in the "package": the LICENSE, README.md  and MANIFEST.in are installed in /usr/lib/python3.8/dist-packages/  directory. Only the real Python package must be installed so the wordlistraider/ directory.

- the entry_point doesn't work. it fails with ```ModuleNotFoundError: No module named 'wordlistraider.wordlistraider'```
it should be ```wordlistraider.WordlistRaider```